### PR TITLE
Proof of concept for using public IPs by the smart client.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -55,6 +55,7 @@ import com.hazelcast.client.spi.impl.ClientTransactionManagerServiceImpl;
 import com.hazelcast.client.spi.impl.ClientUserCodeDeploymentService;
 import com.hazelcast.client.spi.impl.DefaultAddressProvider;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.MembershipAddressTranslator;
 import com.hazelcast.client.spi.impl.NonSmartClientInvocationService;
 import com.hazelcast.client.spi.impl.SmartClientInvocationService;
 import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressProvider;
@@ -249,10 +250,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         partitionService = new ClientPartitionServiceImpl(this);
         discoveryService = initDiscoveryService(config);
         AddressProvider addressProvider = createAddressProvider(externalAddressProvider);
-        AddressTranslator addressTranslator = createAddressTranslator();
+//        AddressTranslator addressTranslator = createAddressTranslator();
+        MembershipAddressTranslator addressTranslator = new MembershipAddressTranslator();
         connectionManager = (ClientConnectionManagerImpl) clientConnectionManagerFactory
                 .createConnectionManager(this, addressTranslator, addressProvider);
         clusterService = new ClientClusterServiceImpl(this);
+        clusterService.addMembershipListener(addressTranslator);
 
 
         invocationService = initInvocationService();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/MembershipAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/MembershipAddressTranslator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.core.InitialMembershipEvent;
+import com.hazelcast.core.InitialMembershipListener;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
+import com.hazelcast.nio.Address;
+
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class MembershipAddressTranslator
+        implements AddressTranslator, MembershipListener, InitialMembershipListener {
+    private volatile Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
+
+    @Override
+    public Address translate(Address address) {
+        if (privateToPublic.containsKey(address)) {
+            return privateToPublic.get(address);
+        }
+        return address;
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public void memberAdded(MembershipEvent membershipEvent) {
+        refresh(membershipEvent.getMembers());
+    }
+
+    @Override
+    public void memberRemoved(MembershipEvent membershipEvent) {
+        refresh(membershipEvent.getMembers());
+    }
+
+    @Override
+    public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+        refresh(memberAttributeEvent.getMembers());
+    }
+
+    @Override
+    public void init(InitialMembershipEvent event) {
+        refresh(event.getMembers());
+    }
+
+    private void refresh(Set<Member> members) {
+        Map<Address, Address> newPrivateToPublic = new HashMap<Address, Address>();
+        for (Member member : members) {
+            if (member.getAttributes().containsKey("publicAddress")) {
+                String[] publicHostPort = member.getAttributes().get("publicAddress").toString().split(":");
+                String host = publicHostPort[0];
+                Integer port = Integer.parseInt(publicHostPort[1]);
+                try {
+                    newPrivateToPublic.put(member.getAddress(), new Address(host, port));
+                } catch (UnknownHostException e) {
+                    // ignore and return the default address
+                }
+            }
+        }
+
+        this.privateToPublic = newPrivateToPublic;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -77,6 +77,9 @@ public class DiscoveryJoiner
         for (DiscoveryNode discoveryNode : discoveredNodes) {
             Address discoveredAddress = usePublicAddress ? discoveryNode.getPublicAddress() : discoveryNode.getPrivateAddress();
             if (localAddress.equals(discoveredAddress)) {
+                Address publicAddress = discoveryNode.getPublicAddress();
+                localMember.setStringAttribute("publicAddress",
+                        String.format("%s:%d", publicAddress.getHost(), publicAddress.getPort()));
                 continue;
             }
             possibleMembers.add(discoveredAddress);


### PR DESCRIPTION
### Problem
Hazelcast cluster is deployed in the cloud environment (AWS, GCP, Kubernetes, Azure, etc.) and each member has both private IP and public IP. The cluster is formed using private IPs. If an external client (client outside the private network) tries to connect to one of the members (usually via Load Balancer), it fetches private IPs and is stuck, because it cannot access the private network.

### Example
![untitled diagram](https://user-images.githubusercontent.com/2834997/50760745-dcb10c00-1268-11e9-9f02-d147f3abfdcb.png)

We have a Hazelcast cluster formed out of 3 members. Each has a private and a public IP address. The cluster is formed using private IPs. Client knows the public address of the Load Balancer, so it:
1. Connects to the Load Balancer 
2. Is forwarded to one of the members
3. Fetches all members addresses, but these are private IP addresses
In result, client has the following information: a list of all members: 192.168.0.1, 192.168.0.2, 192.168.0.3 and is unable to connect to them.

So, we are in the situation in which we have all the information about the public and private addresses in the cluster, but the client is not able to connect to the cluster. Note that using Dumb Client works fine.

### How it works currently
Currently, if client wants to use the private cluster via public IPs, it needs to use a discovery strategy, for example, the hazelcast-aws plugin. Then, internally DiscoveryAddressTranslator is filled with the mapping (private IP -> public IP) and the public addresses are used for the communication.

### Problems with the current solution
The current solution works fine, however has the following issues:
- It requires authentication (e.g. in case of AWS, you need to specify your "access-key" and "secret-key" in the client)
- Not all discovery plugins have the authentication implemented (currently we have it in AWS and GCP, but not in Kubernetes and Azure)
- You have to implement the same thing in each discovery plugin, so the current solution is not generic
- "Smart Client is not so smart", because a user may be surprised that it cannot use the cluster even if she could connect to its member
- Discovery Plugins are only in Java, which makes the Hazelcast cluster not usable in other languages!

### Solution
I made some analysis and I think we can implement it relatively easily by including the public address either in the MemberImpl class or in the member's attributes (that should be safe in terms of the compatibility of the client's protocol). I wrote a proof of concept and it works fine. Please have a look. Obviously it just to show the idea, not the ready implementation, is misses the detection if to use public or private addresses (we need the auto-detection or the additional configuration field).